### PR TITLE
Change config directory to respect xdg base directory spec

### DIFF
--- a/src/pbfetch/main_funcs/handle_config.py
+++ b/src/pbfetch/main_funcs/handle_config.py
@@ -1,4 +1,4 @@
-from pbfetch.main_funcs.stats import stats
+from pbfetch.main_funcs.stats import get_config_dir, stats
 
 import os
 from shutil import copy
@@ -11,7 +11,7 @@ user = stats_dict["$user"]
 
 file = "config.txt"
 usr_tmp = os.path.join("/", "usr", "share", "pbfetch", "config")
-config_directory = os.path.join("/", "home", user, ".config", "pbfetch", "config")
+config_directory = get_config_dir()
 
 
 def handle_config():

--- a/src/pbfetch/main_funcs/stats.py
+++ b/src/pbfetch/main_funcs/stats.py
@@ -22,7 +22,10 @@ import pbfetch.parse_funcs.parse_cpu_usage as cpu_usage
 import subprocess, platform, psutil
 import os
 from os import statvfs
+from pathlib import Path
 
+def get_config_dir():
+    return os.environ.get("XDG_CONFIG_HOME", Path.home().joinpath(".config", "pbfetch"))
 
 def stats():
     # constant for checking cpu usage (in seconds)
@@ -81,12 +84,8 @@ def stats():
     )
     configpath = str(
         os.path.join(
-            "/",
-            "home",
-            stat_user,
-            ".config",
-            "pbfetch",
-            "config"
+            get_config_dir(),
+            "config.txt"
         )
     )
     # stat_shell = shell.parse_shell()


### PR DESCRIPTION
This pr updates the handling of the config directory to respect the appropriate xdg spec: https://specifications.freedesktop.org/basedir-spec/latest/

In practice it means trying  `$XDG_CONFIG_HOME` first and then falling back to `$HOME/.config`
It also uses the appropriate function to fetch the home dir instead of the previous hardcoded version which would fail if the home directory was in a non standard location.